### PR TITLE
remove unused reference to webdam

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -8,7 +8,6 @@
 namespace cweagans\webdam\tests;
 
 use cweagans\webdam\Client;
-use Drupal\media_webdam\Webdam;
 use GuzzleHttp\Client as GClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;


### PR DESCRIPTION
While doing the renaming checks I found an unused reference to Webdam module in the client test.
Removed it.