### PR TITLE
WEBDAM-82 - adding checkCredentials() to validate client details

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -100,6 +100,29 @@ class Client {
   }
 
   /**
+   * Checks if the auth details are correct.
+   *
+   * @param array $client_data
+   *   The client authentication details.
+   */
+  public function checkCredentials($client_data) {
+    $url = $this->baseUrl . '/oauth2/token';
+    try {
+      $this->client->request("POST", $url, ['form_params' => $client_data]);
+    }
+    catch (ClientException $e) {
+      // Any form of bad auth with Webdam is a 400, but we're wrapping
+      // it here just in case.
+      if ($e->getResponse()->getStatusCode() == 400) {
+        $body = (string) $e->getResponse()->getBody();
+        $body = json_decode($body);
+
+        throw new InvalidCredentialsException($body->error_description . ' (' . $body->error . ').');
+      }
+    }
+  }
+
+  /**
    * Authenticates with the Webdam service and retrieves an access token, or uses existing one.
    */
   public function checkAuth() {


### PR DESCRIPTION
Hi, I've added a method in php client to check if the credentials are valid.
It takes the client credentials array params and tries to post to webdam, if the response is 400, throws the InvalidCredentialsException exception.

There is a pending commit for media_webdam > webdamConfig which uses this new method, so once this one gets merged I will push it.
