### PR TITLE
Faster top level folder load

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -268,7 +268,12 @@ class Client {
     $response = $this->client->request(
       "GET",
       $this->baseUrl . '/folders/0',
-      ['headers' => $this->getDefaultHeaders()]
+      [
+        'headers' => $this->getDefaultHeaders(),
+        'query' => [
+          'getchildren' => 'false',
+        ],
+      ]
     );
 
     $folder_data = json_decode($response->getBody());


### PR DESCRIPTION
The setting `getchildren=false` is not documented in the API docs https://www.damsuccess.com/hc/en-us/articles/202134055-REST-API. However, I talked with Webdam team, and they mentioned that this setting will not load children folders.